### PR TITLE
Build and publish docker image on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,21 @@ jobs:
             bazel test //...
             echo 'Development environment verified successfully!'
           "
+  # Build and publish dist image on master branch
+  build-and-publish-dist:
+    name: Build & Publish Dist Image
+    runs-on: ubuntu-latest
+    needs: dev-shell
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v9
+      - name: Login to ghcr.io
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$GH_TOKEN" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
+      - name: Build and push dist image
+        run: |
+          nix develop --command rebuildr load-py ci/dist/dist.rebuildr.py push-image


### PR DESCRIPTION
Add a CI step to build and publish the Docker image tagged `:latest` on every push to the `master` branch.

---
<a href="https://cursor.com/background-agent?bcId=bc-a8a2eb4f-7317-4ff0-99cb-44fe118b3cf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a8a2eb4f-7317-4ff0-99cb-44fe118b3cf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

