### PR TITLE
Build and publish docker image on push and tag

### DIFF
--- a/.github/workflows/docker-dist.yml
+++ b/.github/workflows/docker-dist.yml
@@ -1,0 +1,68 @@
+name: Docker dist image
+
+on:
+  push:
+    branches: [master]
+    tags: ['*']
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image (no push)
+        run: |
+          set -euo pipefail
+          python3 -m rebuildr.cli load-py ci/dist/dist.rebuildr.py materialize-image | cat
+
+      - name: Determine tags
+        id: meta
+        run: |
+          set -euo pipefail
+          IMAGE_REPO="ghcr.io/pawelchcki/rebuildr/dist"
+          TAGS=""
+          if [[ "${GITHUB_REF_TYPE}" == "branch" && "${GITHUB_REF_NAME}" == "master" ]]; then
+            TAGS+="${IMAGE_REPO}:latest"
+          fi
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            TAGS+=" ${IMAGE_REPO}:${GITHUB_REF_NAME}"
+          fi
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+
+      - name: Push content-id tag and add release tags
+        if: steps.meta.outputs.tags != ''
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          # Build and push the content-id tag
+          CONTENT_TAG=$(python3 -m rebuildr.cli load-py ci/dist/dist.rebuildr.py push-image)
+          # Add extra tags (latest or version) to the image just built
+          for T in $TAGS; do
+            docker tag "$CONTENT_TAG" "$T"
+            docker push "$T"
+          done
+


### PR DESCRIPTION
Add GitHub Actions CI to build and publish the `rebuildr/dist` Docker image from `ci/dist/dist.rebuildr.py` to GHCR on `master` pushes (as `:latest`) and on tag pushes (as `<tag>`).

---
<a href="https://cursor.com/background-agent?bcId=bc-30173e77-bfc9-47bc-bdc5-f2ec5e2bf3c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-30173e77-bfc9-47bc-bdc5-f2ec5e2bf3c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

