### PR TITLE
Add alternative image tag to push-image command

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -24,7 +24,7 @@ The `rebuildr` command-line tool is the primary way to use the system. The entry
 
 *   `rebuildr load-py <rebuildr-file>`: Parses a `.rebuildr.py` file and prints its stable descriptor as a JSON object.
 *   `rebuildr load-py <rebuildr-file> materialize-image`: Builds a Docker image from the given `.rebuildr.py` file.
-*   `rebuildr load-py <rebuildr-file> push-image`: Builds and pushes a Docker image to a registry.
+*   `rebuildr load-py <rebuildr-file> push-image [<override-tag>]`: Builds and pushes a Docker image to a registry. If an override tag is provided, the image is re-tagged and the override tag is pushed.
 *   `rebuildr load-py <rebuildr-file> build-tar <output>`: Creates a tar archive from the specified inputs.
 
 ### Building with Bazel

--- a/README.md
+++ b/README.md
@@ -55,8 +55,10 @@ rebuildr load-py <rebuildr-file> [build-arg=value ...] materialize-image
 
 **Build and push Docker image**:
 ```bash
-rebuildr load-py <rebuildr-file> [build-arg=value ...] push-image
+rebuildr load-py <rebuildr-file> [build-arg=value ...] push-image [<override-tag>]
 ```
+
+If `<override-tag>` is provided, the built image will be re-tagged to that value and the override tag will be pushed instead.
 
 **Build tar archive**:
 ```bash

--- a/rebuildr/cli.py
+++ b/rebuildr/cli.py
@@ -190,7 +190,7 @@ def print_usage():
         "  load-py <rebuildr-file> [build-arg=value build-arg2=value2 ...] materialize-image"
     )
     print(
-        "  load-py <rebuildr-file> [build-arg=value build-arg2=value2 ...] push-image"
+        "  load-py <rebuildr-file> [build-arg=value build-arg2=value2 ...] push-image [<override-tag>]"
     )
     print("  load-py <rebuildr-file> build-tar <output>")
 
@@ -250,9 +250,21 @@ def parse_cli_parse_py(args):
         return
 
     if "push-image" == args[0]:
+        override_tag = None
+        if len(args) > 1 and args[1] != "":
+            override_tag = args[1]
+
         tag = build_docker(file_path, build_args, fetch_if_not_local=False)
-        push_image(tag, overwrite_in_registry=False)
-        print(tag)
+
+        if override_tag is not None and override_tag != tag:
+            from rebuildr.containers.util import tag_image
+
+            tag_image(tag, override_tag)
+            push_image(override_tag, overwrite_in_registry=False)
+            print(override_tag)
+        else:
+            push_image(tag, overwrite_in_registry=False)
+            print(tag)
         return
 
     if "build-tar" == args[0]:

--- a/rebuildr/containers/docker.py
+++ b/rebuildr/containers/docker.py
@@ -83,3 +83,9 @@ def docker_push_image(image_tag: str, overwrite_in_registry: bool):
 
     logging.info("Running docker command: {}".format(" ".join(command)))
     subprocess.run(command, check=True)
+
+
+def docker_tag_image(source_tag: str, target_tag: str):
+    command = [str(docker_bin()), "image", "tag", source_tag, target_tag]
+    logging.info("Running docker command: {}".format(" ".join(command)))
+    subprocess.run(command, check=True)

--- a/rebuildr/containers/util.py
+++ b/rebuildr/containers/util.py
@@ -5,6 +5,7 @@ from rebuildr.containers.docker import (
     docker_image_exists_locally,
     docker_pull_image,
     docker_push_image,
+    docker_tag_image,
     is_docker_available,
 )
 
@@ -37,3 +38,10 @@ def push_image(image_tag: str, overwrite_in_registry: bool = False):
         docker_push_image(image_tag, overwrite_in_registry)
     else:
         logging.warning("Docker is not available to push image")
+
+
+def tag_image(source_tag: str, target_tag: str):
+    if is_docker_available():
+        docker_tag_image(source_tag, target_tag)
+    else:
+        logging.warning("Docker is not available to tag image")


### PR DESCRIPTION
Add an optional `override-tag` argument to the `push-image` command to allow specifying an alternative tag for the pushed Docker image.

---
<a href="https://cursor.com/background-agent?bcId=bc-5cbdfb14-7cd6-4eff-99ae-a83890645a6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5cbdfb14-7cd6-4eff-99ae-a83890645a6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

