### PR TITLE
Build and push dist image on new tag

### DIFF
--- a/.github/workflows/release-dist.yml
+++ b/.github/workflows/release-dist.yml
@@ -1,0 +1,41 @@
+name: Publish dist image on tag
+
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push-dist:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU (for multi-arch, optional)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push dist image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ci/dist/dist.Dockerfile
+          push: true
+          tags: |
+            ghcr.io/pawelchcki/rebuildr/dist:${{ github.ref_name }}
+            ghcr.io/pawelchcki/rebuildr/dist:latest


### PR DESCRIPTION
Add a GitHub Actions workflow to build and push the `dist` Docker image to GitHub Container Registry on new tag pushes.

---
<a href="https://cursor.com/background-agent?bcId=bc-46c44029-7381-4ed7-85ad-ea8a6fb7ebeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-46c44029-7381-4ed7-85ad-ea8a6fb7ebeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

