### PR TITLE
Build and push dist image on new tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,3 +22,27 @@ jobs:
             exit 1
           fi
           nix flake check
+
+  # Build and publish dist image with tag
+  build-and-publish-dist:
+    name: Build & Publish Dist Image
+    runs-on: ubuntu-latest
+    needs: pre-release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v9
+      - name: Login to ghcr.io
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$GH_TOKEN" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
+      - name: Get tag name
+        id: get_tag
+        run: echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+      - name: Build and push dist image with tag
+        run: |
+          # Build and push with the version tag
+          REBUILDR_TAG="${{ steps.get_tag.outputs.TAG_NAME }}" nix develop --command rebuildr load-py ci/dist/dist.rebuildr.py push-image
+          # Also push as latest
+          REBUILDR_TAG="latest" nix develop --command rebuildr load-py ci/dist/dist.rebuildr.py push-image

--- a/ci/dist/dist.rebuildr.py
+++ b/ci/dist/dist.rebuildr.py
@@ -1,14 +1,18 @@
 #! /usr/bin/env nix
 #! nix shell path:../.. --command rebuildr load-py
 
+import os
 from rebuildr.descriptor import Descriptor, FileInput, GlobInput, ImageTarget, Inputs
+
+# Get tag from environment variable, default to "latest"
+tag = os.environ.get("REBUILDR_TAG", "latest")
 
 image = Descriptor(
     targets=[
         ImageTarget(
             dockerfile="dist.Dockerfile",
             repository="ghcr.io/pawelchcki/rebuildr/dist",
-            tag="latest",
+            tag=tag,
         )
     ],
     inputs=Inputs(


### PR DESCRIPTION
Add a GitHub Actions job to build and push the `dist` Docker image with both the release tag and `latest` tag when a new version tag is pushed.

The `dist.rebuildr.py` script was updated to dynamically use the tag provided via an environment variable, allowing the same script to be used for both versioned releases and the `latest` tag. This ensures that releases have specific image versions and `latest` is always up-to-date.

---
<a href="https://cursor.com/background-agent?bcId=bc-d722b173-e472-443e-b873-bee75a95fcf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d722b173-e472-443e-b873-bee75a95fcf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

